### PR TITLE
Adds creation timestamp to PG/User details

### DIFF
--- a/src/main/java/app/netlify/dsubha/entity/PG.java
+++ b/src/main/java/app/netlify/dsubha/entity/PG.java
@@ -153,6 +153,7 @@ public class PG {
 			userPG.put("email", e.getUser().getEmail());
 			userPG.put("contactNo", e.getUser().getContactNo());
 			userPG.put("photoUrl", e.getUser().getPhotoUrl());
+			userPG.put("created", e.getUser().getCreated());
 			return userPG;
 		}).toList();
 		return userPGs;
@@ -172,6 +173,7 @@ public class PG {
 		admin.put("email", this.admin.getUser().getEmail());
 		admin.put("contactNo", this.admin.getUser().getContactNo());
 		admin.put("photoUrl", this.admin.getUser().getPhotoUrl());
+		admin.put("created", this.admin.getUser().getCreated());
 		return admin;
 	}
 

--- a/src/main/java/app/netlify/dsubha/entity/User.java
+++ b/src/main/java/app/netlify/dsubha/entity/User.java
@@ -116,6 +116,7 @@ public class User {
 			userPG.put("address", e.getPg().getAddress());
 			userPG.put("website", e.getPg().getWebsite());
 			userPG.put("timezone", e.getPg().getTimezone());
+			userPG.put("created", e.getPg().getCreated());
 			return userPG;
 		}).toList();
 		return userPGs;
@@ -136,6 +137,7 @@ public class User {
 			admin.put("address", e.getPg().getAddress());
 			admin.put("website", e.getPg().getWebsite());
 			admin.put("timezone", e.getPg().getTimezone());
+			admin.put("created", e.getPg().getCreated());
 			return admin;
 		}).toList();
 		return admins;


### PR DESCRIPTION
Adds the 'created' timestamp to the PG and User details returned in API responses.

This ensures that the creation time of these entities is available in the relevant data structures.